### PR TITLE
Independent Operations and CustomDioInterceptor for access token refr…

### DIFF
--- a/commanddash/.gitignore
+++ b/commanddash/.gitignore
@@ -6,3 +6,4 @@ bin/*.dill
 out.js
 out.js.deps
 out.js.map
+*.mocks.dart

--- a/commanddash/lib/repositories/client/dio_client.dart
+++ b/commanddash/lib/repositories/client/dio_client.dart
@@ -1,0 +1,98 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:dio/dio.dart';
+
+typedef RefreshAccessToken = Future<Map<String, dynamic>> Function();
+
+Dio getClient(String accessToken, RefreshAccessToken updateAccessToken) {
+  final dio = Dio();
+  dio.options.baseUrl = 'https://api.commanddash.dev';
+  dio.interceptors.add(CustomInterceptor(
+      dio: dio,
+      accessToken: accessToken,
+      updateAccessToken: updateAccessToken));
+  return dio;
+}
+
+class CustomInterceptor extends Interceptor {
+  CustomInterceptor(
+      {required this.dio,
+      required this.accessToken,
+      required this.updateAccessToken,
+      this.apiKey});
+  final Dio dio;
+  String accessToken;
+  RefreshAccessToken updateAccessToken;
+  String? apiKey;
+
+  @override
+  void onRequest(
+      RequestOptions options, RequestInterceptorHandler handler) async {
+    options.headers['Authorization'] = 'Bearer $accessToken';
+    options.headers['X-API-Key'] = '$apiKey';
+    return handler.next(options);
+  }
+
+  @override
+  void onResponse(Response response, ResponseInterceptorHandler handler) {
+    response.data = jsonDecode(response.data);
+    handler.resolve(response);
+  }
+
+  @override
+  Future<void> onError(
+      DioException err, ErrorInterceptorHandler handler) async {
+    if (err.response != null && err.response!.statusCode == 401) {
+      try {
+        final tokenResponse = await updateAccessToken();
+        if (tokenResponse['access_token'] == null) {
+          throw Exception('Unable to refresh github access token');
+        }
+        accessToken = tokenResponse['access_token'];
+
+        // Retry the original request
+        final opts = err.requestOptions;
+        opts.headers['Authorization'] = 'Bearer $accessToken';
+
+        final response = await dio.fetch(opts);
+        handler.resolve(response);
+      } on DioException catch (e) {
+        // if [updateAccessToken] or [dio.fetch] fails
+        handler.next(e);
+      }
+    } else {
+      handler.next(err);
+    }
+  }
+}
+
+UserException userException(Exception e) {
+  if (e is DioException) {
+    if (e.response != null) {
+      return UserException(
+          statusCode: e.response!.statusCode,
+          message: e.response!.data['message']);
+    } else {
+      return UserException(message: e.message);
+    }
+  } else {
+    throw UserException(message: e.toString());
+  }
+}
+
+class UserException implements Exception {
+  UserException({this.statusCode, this.message});
+
+  final int? statusCode;
+  final String? message;
+
+  @override
+  String toString() {
+    if (statusCode != null) {
+      return '$statusCode $message';
+    } else {
+      return '$message';
+    }
+  }
+}

--- a/commanddash/lib/repositories/dash_repository.dart
+++ b/commanddash/lib/repositories/dash_repository.dart
@@ -1,0 +1,12 @@
+import 'package:dio/dio.dart';
+
+class DashRepository {
+  DashRepository(this.dio);
+  final Dio dio;
+
+  /// Error is handled and thrown back from the interceptor. Add a try catch at step level.
+  Future<void> mockApi() async {
+    final response = await dio.get('/path');
+    return response.data;
+  }
+}

--- a/commanddash/lib/server/messages.dart
+++ b/commanddash/lib/server/messages.dart
@@ -1,4 +1,7 @@
-class IncomingMessage {
+import 'package:commanddash/server/operation_message.dart';
+import 'package:equatable/equatable.dart';
+
+class IncomingMessage extends Equatable {
   final int id;
   const IncomingMessage(this.id);
 
@@ -9,14 +12,20 @@ class IncomingMessage {
         final taskKind = json['params']['kind'];
         final taskData = json['params']['data'];
         return TaskStartMessage(taskId, taskKind: taskKind, data: taskData);
-      case 'process_step_response':
+      case 'step_response':
         final taskId = json['id'];
-        final responseData = json['params'];
-        return ProcessResponseMessage(taskId, data: responseData);
+        final responseData = json['data'];
+        return StepResponseMessage(taskId, json['kind'], data: responseData);
+      case 'operation_response':
+        final responseData = json['data'];
+        return OperationResponseMessage(json['kind'], data: responseData);
       default:
         throw UnimplementedError();
     }
   }
+
+  @override
+  List<Object?> get props => [id];
 }
 
 class TaskStartMessage extends IncomingMessage {
@@ -24,18 +33,29 @@ class TaskStartMessage extends IncomingMessage {
   final Map<String, dynamic> data;
   TaskStartMessage(int id, {required this.taskKind, required this.data})
       : super(id);
+
+  @override
+  List<Object?> get props => [...super.props, taskKind, data];
 }
 
-class ProcessResponseMessage extends IncomingMessage {
+class StepResponseMessage extends IncomingMessage {
+  final String kind;
   final Map<String, dynamic> data;
-  ProcessResponseMessage(int id, {required this.data}) : super(id);
+
+  StepResponseMessage(int id, this.kind, {required this.data}) : super(id);
+
+  @override
+  List<Object?> get props => [...super.props, kind, data];
 }
 
-class OutgoingMessage {
+class OutgoingMessage extends Equatable {
   final int id;
   const OutgoingMessage(this.id);
 
   Map<String, dynamic> get toJson => {'id': id};
+
+  @override
+  List<Object?> get props => [id];
 }
 
 class ResultMessage extends OutgoingMessage {
@@ -56,6 +76,9 @@ class ResultMessage extends OutgoingMessage {
     });
     return json;
   }
+
+  @override
+  List<Object?> get props => [...super.props, message, data];
 }
 
 class ErrorMessage extends OutgoingMessage {
@@ -75,8 +98,12 @@ class ErrorMessage extends OutgoingMessage {
     });
     return json;
   }
+
+  @override
+  List<Object?> get props => [...super.props, message, data];
 }
 
+/// Log Message is sent to log something in the client side for debugging purpose.
 class LogMessage extends OutgoingMessage {
   final String message;
   final Map<String, dynamic> data;
@@ -94,19 +121,24 @@ class LogMessage extends OutgoingMessage {
     });
     return json;
   }
+
+  @override
+  List<Object?> get props => [...super.props, message, data];
 }
 
-/// To be used to communicate with client to execute any user facing tasks or fetch data from client.
-class ProcessMessage extends OutgoingMessage {
+/// Step messages are continuous messages sent to client while executing a task.
+/// [id] represents the taskId
+/// Client returns -> [StepResponseMessage]
+class StepMessage extends OutgoingMessage {
   final String kind;
   final Map<String, dynamic> args;
-  ProcessMessage(int id, {required this.kind, required this.args}) : super(id);
+  StepMessage(int id, {required this.kind, required this.args}) : super(id);
 
   @override
   Map<String, dynamic> get toJson {
     final json = super.toJson;
     json.addAll({
-      'method': 'process_step',
+      'method': 'step',
       'params': {
         'kind': kind,
         'args': args,
@@ -114,4 +146,7 @@ class ProcessMessage extends OutgoingMessage {
     });
     return json;
   }
+
+  @override
+  List<Object?> get props => [...super.props, kind, args];
 }

--- a/commanddash/lib/server/operation_message.dart
+++ b/commanddash/lib/server/operation_message.dart
@@ -1,0 +1,34 @@
+import 'package:commanddash/server/messages.dart';
+
+class OperationResponseMessage extends IncomingMessage {
+  final String kind;
+  final Map<String, dynamic> data;
+
+  OperationResponseMessage(this.kind, {required this.data}) : super(-1);
+
+  @override
+  List<Object?> get props => [kind, data];
+}
+
+/// [OperationMesssage] are one-off messages sent from CLI to Client that are not just scoped to a single task.
+/// [id] here represents the OperationID.
+/// Client returns -> [OperationResponseMessage]
+class OperationMessage extends OutgoingMessage {
+  final String kind;
+  final Map<String, dynamic> args;
+  OperationMessage({required this.kind, required this.args}) : super(-1);
+  @override
+  Map<String, dynamic> get toJson {
+    return {
+      'id': -1,
+      'method': 'operation',
+      'params': {
+        'kind': kind,
+        'args': args,
+      },
+    };
+  }
+
+  @override
+  List<Object?> get props => [kind, args];
+}

--- a/commanddash/lib/server/task_assist.dart
+++ b/commanddash/lib/server/task_assist.dart
@@ -1,4 +1,5 @@
 import 'package:commanddash/server/messages.dart';
+import 'package:commanddash/server/operation_message.dart';
 import 'package:commanddash/server/server.dart';
 import 'package:rxdart/rxdart.dart';
 
@@ -9,9 +10,9 @@ class TaskAssist {
 
   Future<Map<String, dynamic>> processStep(
       {required String kind, required Map<String, dynamic> args}) async {
-    _server.sendMessage(ProcessMessage(_taskId, kind: kind, args: args));
+    _server.sendMessage(StepMessage(_taskId, kind: kind, args: args));
     final dataResponse = await _server.messagesStream
-        .whereType<ProcessResponseMessage>()
+        .whereType<StepResponseMessage>()
         .where((event) => event.id == _taskId)
         .first;
     return dataResponse.data;
@@ -30,5 +31,19 @@ class TaskAssist {
   /// Only use for debugging purposes. Clients can print the log on their end.
   void sendLogMessage({required message, required Map<String, dynamic> data}) {
     _server.sendMessage(LogMessage(_taskId, message: message, data: data));
+  }
+
+  /// To perform task independent operationas such as asking client to refresh and provide new access token.
+  Future<Map<String, dynamic>> processOperation({
+    required String kind,
+    required Map<String, dynamic> args,
+  }) async {
+    _server.sendMessage(OperationMessage(kind: kind, args: args));
+
+    final dataResponse = await _server.messagesStream
+        .whereType<OperationResponseMessage>()
+        .where((event) => event.kind == kind)
+        .first;
+    return dataResponse.data;
   }
 }

--- a/commanddash/lib/server/task_handler.dart
+++ b/commanddash/lib/server/task_handler.dart
@@ -1,8 +1,10 @@
-import 'package:commanddash/steps/find_closest_files/embedding_generator.dart';
+import 'package:commanddash/repositories/client/dio_client.dart';
+import 'package:commanddash/repositories/dash_repository.dart';
 import 'package:commanddash/repositories/gemini_repository.dart';
 import 'package:commanddash/server/messages.dart';
 import 'package:commanddash/server/server.dart';
 import 'package:commanddash/server/task_assist.dart';
+import 'package:commanddash/steps/find_closest_files/embedding_generator.dart';
 import 'package:rxdart/rxdart.dart';
 
 class TaskHandler {
@@ -14,8 +16,21 @@ class TaskHandler {
         .listen((TaskStartMessage message) {
       final taskAssist = TaskAssist(_server, message.id);
       switch (message.taskKind) {
-        case 'random_task':
-          someRandomFunction(taskAssist);
+        case 'random_task_with_step':
+          randomFunctionWithStep(taskAssist);
+          break;
+        case 'random_task_with_side_operation':
+          randomFunctionWithSideOperation(taskAssist);
+          break;
+        case 'refresh_token_test':
+          final client = getClient(
+              message.data['auth']['github_access_token'],
+              () async => taskAssist
+                  .processOperation(kind: 'refresh_access_token', args: {}));
+          DashRepository(client);
+
+          ///Other repositories using the backend client
+          ///Pass this to the agent.
           break;
         case 'find_closest_files':
           EmbeddingGenerator().findClosesResults(
@@ -32,11 +47,25 @@ class TaskHandler {
   }
 }
 
-Future<void> someRandomFunction(TaskAssist taskAssist) async {
-  final data = await taskAssist.processStep(kind: 'random_data_kind', args: {});
+/// Function for Integration Test of the step communication
+Future<void> randomFunctionWithStep(TaskAssist taskAssist) async {
+  final data = await taskAssist.processStep(kind: 'step_data_kind', args: {});
   if (data['value'] == 'unique_value') {
     taskAssist.sendResultMessage(message: 'TASK_COMPLETED', data: {});
   } else {
     taskAssist.sendErrorMessage(message: 'TASK_FAILED', data: {});
   }
+}
+
+/// Function for Integration Test of the side operation communication
+Future<void> randomFunctionWithSideOperation(TaskAssist taskAssist) async {
+  /// added these logs for debugging purposes on client
+  taskAssist.sendLogMessage(
+      message: 'operation_data_kind_request_received', data: {});
+
+  final data =
+      await taskAssist.processOperation(kind: 'operation_data_kind', args: {});
+  taskAssist.sendLogMessage(
+      message: 'operation_data_kind_received', data: data);
+  taskAssist.sendResultMessage(message: 'TASK_COMPLETED', data: {});
 }

--- a/commanddash/pubspec.lock
+++ b/commanddash/pubspec.lock
@@ -41,6 +41,78 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
+  build:
+    dependency: transitive
+    description:
+      name: build
+      sha256: "80184af8b6cb3e5c1c4ec6d8544d27711700bc3e6d2efad04238c7b5290889f0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  build_config:
+    dependency: transitive
+    description:
+      name: build_config
+      sha256: bf80fcfb46a29945b423bd9aad884590fb1dc69b330a4d4700cac476af1708d1
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
+  build_daemon:
+    dependency: transitive
+    description:
+      name: build_daemon
+      sha256: "0343061a33da9c5810b2d6cee51945127d8f4c060b7fbdd9d54917f0a3feaaa1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.1"
+  build_resolvers:
+    dependency: transitive
+    description:
+      name: build_resolvers
+      sha256: "339086358431fa15d7eca8b6a36e5d783728cf025e559b834f4609a1fcfb7b0a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.2"
+  build_runner:
+    dependency: "direct dev"
+    description:
+      name: build_runner
+      sha256: "581bacf68f89ec8792f5e5a0b2c4decd1c948e97ce659dc783688c8a88fbec21"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.8"
+  build_runner_core:
+    dependency: transitive
+    description:
+      name: build_runner_core
+      sha256: "4ae8ffe5ac758da294ecf1802f2aff01558d8b1b00616aa7538ea9a8a5d50799"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.3.0"
+  built_collection:
+    dependency: transitive
+    description:
+      name: built_collection
+      sha256: "376e3dd27b51ea877c28d525560790aee2e6fbb5f20e2f85d5081027d94e2100"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.1.1"
+  built_value:
+    dependency: transitive
+    description:
+      name: built_value
+      sha256: fedde275e0a6b798c3296963c5cd224e3e1b55d0e478d5b7e65e6b540f363a0e
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.9.1"
+  checked_yaml:
+    dependency: transitive
+    description:
+      name: checked_yaml
+      sha256: feb6bed21949061731a7a75fc5d2aa727cf160b91af9a3e464c5e3a32e28b5ff
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.3"
   cli_util:
     dependency: "direct main"
     description:
@@ -49,6 +121,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.4.1"
+  code_builder:
+    dependency: transitive
+    description:
+      name: code_builder
+      sha256: f692079e25e7869c14132d39f223f8eec9830eb76131925143b2129c4bb01b37
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.10.0"
   collection:
     dependency: transitive
     description:
@@ -81,6 +161,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.3"
+  dart_style:
+    dependency: transitive
+    description:
+      name: dart_style
+      sha256: "99e066ce75c89d6b29903d788a7bb9369cf754f7b24bf70bf4b6d6d6b26853b9"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.6"
+  dio:
+    dependency: "direct main"
+    description:
+      name: dio
+      sha256: "49af28382aefc53562459104f64d16b9dfd1e8ef68c862d5af436cc8356ce5a8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.4.1"
+  equatable:
+    dependency: "direct main"
+    description:
+      name: equatable
+      sha256: c2b87cb7756efdf69892005af546c56c0b5037f54d2a88269b4f347a505e3ca2
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.5"
   file:
     dependency: transitive
     description:
@@ -89,6 +193,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.0"
+  fixnum:
+    dependency: transitive
+    description:
+      name: fixnum
+      sha256: "25517a4deb0c03aa0f32fd12db525856438902d9c16536311e76cdc57b31d7d1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
   frontend_server_client:
     dependency: transitive
     description:
@@ -105,6 +217,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
+  google_generative_ai:
+    dependency: "direct main"
+    description:
+      name: google_generative_ai
+      sha256: b2d3f7277a85e3e6be4c4392c59e73ea211b5b6c8bb21c24c71fd411a2d1822e
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.2"
+  graphs:
+    dependency: transitive
+    description:
+      name: graphs
+      sha256: aedc5a15e78fc65a6e23bcd927f24c64dd995062bcd1ca6eda65a3cff92a4d19
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.1"
+  http:
+    dependency: transitive
+    description:
+      name: http
+      sha256: a2bbf9d017fcced29139daa8ed2bba4ece450ab222871df93ca9eec6f80c34ba
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.0"
   http_multi_server:
     dependency: transitive
     description:
@@ -137,6 +273,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.1"
+  json_annotation:
+    dependency: transitive
+    description:
+      name: json_annotation
+      sha256: b10a7b2ff83d83c777edba3c6a0f97045ddadd56c944e1a23a3fdf43a1bf4467
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.8.1"
   lints:
     dependency: "direct dev"
     description:
@@ -177,6 +321,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
+  mockito:
+    dependency: "direct dev"
+    description:
+      name: mockito
+      sha256: "6841eed20a7befac0ce07df8116c8b8233ed1f4486a7647c7fc5a02ae6163917"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.4.4"
   node_preamble:
     dependency: transitive
     description:
@@ -217,6 +369,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  pubspec_parse:
+    dependency: transitive
+    description:
+      name: pubspec_parse
+      sha256: c63b2876e58e194e4b0828fcb080ad0e06d051cb607a6be51a9e084f47cb9367
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.3"
   rxdart:
     dependency: "direct main"
     description:
@@ -257,6 +417,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.4"
+  source_gen:
+    dependency: transitive
+    description:
+      name: source_gen
+      sha256: "14658ba5f669685cd3d63701d01b31ea748310f7ab854e471962670abcf57832"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.5.0"
   source_map_stack_trace:
     dependency: transitive
     description:
@@ -297,6 +465,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
+  stream_transform:
+    dependency: transitive
+    description:
+      name: stream_transform
+      sha256: "14a00e794c7c11aa145a170587321aedce29769c08d7f58b1d141da75e3b1c6f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
   string_scanner:
     dependency: transitive
     description:
@@ -337,6 +513,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.6.0"
+  timing:
+    dependency: transitive
+    description:
+      name: timing
+      sha256: "70a3b636575d4163c477e6de42f247a23b315ae20e86442bebe32d3cabf61c32"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.1"
   typed_data:
     dependency: transitive
     description:

--- a/commanddash/pubspec.yaml
+++ b/commanddash/pubspec.yaml
@@ -12,10 +12,15 @@ dependencies:
   args: ^2.4.2
   async: ^2.11.0
   cli_util: ^0.4.1
+  dio: ^5.4.1
+  equatable: ^2.0.5
   google_generative_ai: ^0.2.2
   rxdart: ^0.27.7
   # path: ^1.8.0
 
 dev_dependencies:
   lints: ^2.1.0
+  build_runner: ^2.4.8
+  mockito: ^5.4.4
   test: ^1.24.0
+  

--- a/commanddash/test/generation_repositories/client/dio_client_test.dart
+++ b/commanddash/test/generation_repositories/client/dio_client_test.dart
@@ -1,0 +1,140 @@
+import 'package:commanddash/repositories/client/dio_client.dart';
+import 'package:dio/dio.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+import 'package:test/test.dart';
+
+import 'dio_client_test.mocks.dart';
+
+@GenerateMocks([Dio, RequestInterceptorHandler, ErrorInterceptorHandler])
+void main() {
+  late MockDio dio;
+  late MockErrorInterceptorHandler errorInterceptorHandler;
+  late CustomInterceptor customInterceptor;
+
+  setUp(() {
+    dio = MockDio();
+    errorInterceptorHandler = MockErrorInterceptorHandler();
+    customInterceptor = CustomInterceptor(
+      dio: dio,
+      accessToken: 'access-token',
+      updateAccessToken: () async {
+        return {'access_token': 'new-access-token'};
+      },
+    );
+  });
+
+  group('CustomInterceptor', () {
+    test('sends access token in header', () async {
+      final requestOptions = RequestOptions(path: '/api/v1/users');
+      customInterceptor.onRequest(requestOptions, RequestInterceptorHandler());
+
+      expect(requestOptions.headers['Authorization'], 'Bearer access-token');
+    });
+
+    group('onError', () {
+      test('updates access token and retries request on 401 status code',
+          () async {
+        final requestOptions = RequestOptions(path: '/api/v1/users');
+        final dioError = DioException(
+          requestOptions: requestOptions,
+          response: Response(
+            statusCode: 401,
+            requestOptions: requestOptions,
+          ),
+        );
+        final response =
+            Response(data: '{"id": 1}', requestOptions: requestOptions);
+        when(dio.fetch(requestOptions)).thenAnswer((_) async => response);
+
+        await customInterceptor.onError(dioError, errorInterceptorHandler);
+
+        verify(dio.fetch(requestOptions));
+        verify(errorInterceptorHandler.resolve(response));
+        expect(
+            requestOptions.headers['Authorization'], 'Bearer new-access-token');
+      });
+
+      test('passes error to handler on non-401 status code', () async {
+        final requestOptions = RequestOptions(path: '/api/v1/users');
+        final dioError = DioException(
+          requestOptions: requestOptions,
+          response: Response(
+            statusCode: 500,
+            requestOptions: requestOptions,
+          ),
+        );
+
+        await customInterceptor.onError(dioError, errorInterceptorHandler);
+        verify(errorInterceptorHandler.next(dioError));
+        verifyNever(dio.fetch(any));
+      });
+
+      test('passes error to handler when updateAccessToken throws an exception',
+          () async {
+        final requestOptions = RequestOptions(path: '/api/v1/users');
+        final exception = DioException(requestOptions: requestOptions);
+        customInterceptor = CustomInterceptor(
+          dio: dio,
+          accessToken: 'access-token',
+          updateAccessToken: () async {
+            throw exception;
+          },
+        );
+
+        final dioError = DioException(
+          requestOptions: requestOptions,
+          response: Response(
+            statusCode: 401,
+            requestOptions: requestOptions,
+          ),
+        );
+
+        await customInterceptor.onError(dioError, errorInterceptorHandler);
+        verifyNever(dio.fetch(any));
+        verifyNever(errorInterceptorHandler.resolve(any));
+        verify(errorInterceptorHandler.next(exception));
+      });
+      test('passes error to handler when dio.fetch throws an exception',
+          () async {
+        final requestOptions = RequestOptions(path: '/api/v1/users');
+        final exception = DioException(requestOptions: requestOptions);
+        final dioError = DioException(
+          requestOptions: requestOptions,
+          response: Response(
+            statusCode: 401,
+            requestOptions: requestOptions,
+          ),
+        );
+        when(dio.fetch(requestOptions)).thenThrow(exception);
+        await customInterceptor.onError(dioError, errorInterceptorHandler);
+        verify(dio.fetch(any));
+        verifyNever(errorInterceptorHandler.resolve(any));
+        verify(errorInterceptorHandler.next(exception));
+      });
+      test('throws error when updateAccessToken doesn\'t return access token',
+          () async {
+        final requestOptions = RequestOptions(path: '/api/v1/users');
+        customInterceptor = CustomInterceptor(
+          dio: dio,
+          accessToken: 'access-token',
+          updateAccessToken: () async {
+            return {};
+          },
+        );
+        final dioError = DioException(
+          requestOptions: requestOptions,
+          response: Response(
+            statusCode: 401,
+            requestOptions: requestOptions,
+          ),
+        );
+
+        expect(
+            () async => await customInterceptor.onError(
+                dioError, errorInterceptorHandler),
+            throwsA(const TypeMatcher<Exception>()));
+      });
+    });
+  });
+}

--- a/commanddash/test/process_command_test.dart
+++ b/commanddash/test/process_command_test.dart
@@ -1,81 +1,168 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 import 'package:async/async.dart';
 import 'package:test/test.dart';
 
+///TODO[FIX]: Tests fail when ran at once.
 void main() {
-  test('Valid Task Kind with Additional Data', () async {
-    final process = await Process.start(
-        'dart', ['run', 'bin/commanddash.dart', 'process'],
-        runInShell: true);
-    final processOutput = process.stdout.transform(utf8.decoder);
-    final queue = StreamQueue<String>(processOutput);
-    // send a task start message
-    process.stdin.writeln(jsonEncode({
-      'method': 'task_start',
-      'id': 1,
-      'params': {
-        'data': {'example': 'data'},
-        'kind': 'random_task',
-      }
-    }));
-    // expect the server to ask for additional data
-    var result = await queue.next;
-    expect(
-        jsonDecode(result),
-        equals({
-          'method': 'process_step',
-          'id': 1,
-          'params': {'kind': 'random_data_kind', 'args': {}}
-        }));
-    // send additional data
-    process.stdin.writeln(jsonEncode({
-      'method': 'process_step_response',
-      'id': 1,
-      'params': {'value': 'unique_value'}
-    }));
-    result = await queue.next;
-    expect(
-        jsonDecode(result),
-        equals({
-          'method': 'result',
-          'id': 1,
-          'params': {'message': 'TASK_COMPLETED', 'data': {}}
-        }));
+  group('Task with process step, ', () {
+    test('Valid Task Kind', () async {
+      final process = await Process.start(
+          'dart', ['run', 'bin/commanddash.dart', 'process'],
+          runInShell: true);
+      final processOutput = process.stdout.transform(utf8.decoder);
+      final queue = StreamQueue<String>(processOutput);
+      // send a task start message
+      process.stdin.writeln(jsonEncode({
+        'method': 'task_start',
+        'id': 1,
+        'params': {
+          'data': {'example': 'data'},
+          'kind': 'random_task_with_step',
+        }
+      }));
+      // expect the server to ask for additional data
+      var result = await queue.next;
+      expect(
+          jsonDecode(result),
+          equals({
+            'method': 'step',
+            'id': 1,
+            'params': {'kind': 'step_data_kind', 'args': {}}
+          }));
+      // send additional data
+      process.stdin.writeln(jsonEncode({
+        'method': 'step_response',
+        'id': 1,
+        'kind': 'step_data_kind',
+        'data': {'value': 'unique_value'}
+      }));
+      result = await queue.next;
+      expect(
+          jsonDecode(result),
+          equals({
+            'method': 'result',
+            'id': 1,
+            'params': {'message': 'TASK_COMPLETED', 'data': {}}
+          }));
 
-    // close the process
-    process.stdin.writeln('exit');
-    await expectLater(await process.exitCode, 0);
+      // close the process
+      process.stdin.writeln('exit');
+      await expectLater(await process.exitCode, 0);
+    });
+    test('Invalid Task Kind', () async {
+      final process = await Process.start(
+          'dart', ['run', 'bin/commanddash.dart', 'process'],
+          runInShell: true);
+      final processOutput = process.stdout.transform(utf8.decoder);
+      final queue = StreamQueue<String>(processOutput);
+      // send an invalid task start message
+      process.stdin.writeln(jsonEncode({
+        'method': 'task_start',
+        'id': 1,
+        'params': {
+          'data': {'example': 'data'},
+          'kind': 'invalid_task',
+        }
+      }));
+
+      var result = await queue.next;
+      expect(
+          jsonDecode(result),
+          equals({
+            'method': 'error',
+            'id': 1,
+            'params': {
+              'message': 'INVALID_TASK_KIND',
+              'data': {},
+            }
+          }));
+
+      // close the process
+      process.stdin.writeln('exit');
+      await expectLater(await process.exitCode, 0);
+    });
   });
-  test('Invalid Task Kind', () async {
-    final process = await Process.start(
-        'dart', ['run', 'bin/commanddash.dart', 'process'],
-        runInShell: true);
-    final processOutput = process.stdout.transform(utf8.decoder);
-    final queue = StreamQueue<String>(processOutput);
-    // send an invalid task start message
-    process.stdin.writeln(jsonEncode({
-      'method': 'task_start',
-      'id': 1,
-      'params': {
-        'data': {'example': 'data'},
-        'kind': 'invalid_task',
-      }
-    }));
-    var result = await queue.next;
-    expect(
-        jsonDecode(result),
-        equals({
-          'method': 'error',
-          'id': 1,
-          'params': {
-            'message': 'INVALID_TASK_KIND',
-            'data': {},
-          }
-        }));
 
-    // close the process
-    process.stdin.writeln('exit');
-    await expectLater(await process.exitCode, 0);
+  group('Task with side operation, ', () {
+    test('Valid Task Kind executes succesfully', () async {
+      final process = await Process.start(
+          'dart', ['run', 'bin/commanddash.dart', 'process'],
+          runInShell: true);
+
+      final processOutput = process.stdout.transform(utf8.decoder);
+      final queue = StreamQueue<String>(processOutput);
+      // send a task start message
+      process.stdin.writeln(jsonEncode({
+        'method': 'task_start',
+        'id': 1,
+        'params': {
+          'data': {'example': 'data'},
+          'kind': 'random_task_with_side_operation',
+        }
+      }));
+      // expect the server to send an operation message
+      var result = await queue.next;
+      expect(
+          jsonDecode(result),
+          equals({
+            'method': 'operation',
+            'params': {'kind': 'operation_data_kind', 'args': {}}
+          }));
+      // send an operation response message
+      process.stdin.writeln(jsonEncode({
+        'method': 'operation_response',
+        'kind': 'operation_data_kind',
+        'data': {'value': 'operation_value'}
+      }));
+      result = await queue.next;
+      expect(
+          jsonDecode(result),
+          equals({
+            'method': 'result',
+            'id': 1,
+            'params': {'message': 'TASK_COMPLETED', 'data': {}}
+          }));
+
+      // close the process
+      process.stdin.writeln('exit');
+      await expectLater(await process.exitCode, 0);
+    });
+    test('Invalid Task Kind never finishes', () async {
+      final process = await Process.start(
+          'dart', ['run', 'bin/commanddash.dart', 'process'],
+          runInShell: true);
+      final processOutput = process.stdout.transform(utf8.decoder);
+      final queue = StreamQueue<String>(processOutput);
+      // send a task start message
+      process.stdin.writeln(jsonEncode({
+        'method': 'task_start',
+        'id': 1,
+        'params': {
+          'data': {'example': 'data'},
+          'kind': 'random_task_with_side_operation',
+        }
+      }));
+      // expect the server to send an operation message
+      var result = await queue.next;
+      expect(
+          jsonDecode(result),
+          equals({
+            'method': 'operation',
+            'params': {'kind': 'operation_data_kind', 'args': {}}
+          }));
+      // send an operation response message
+      process.stdin.writeln(jsonEncode({
+        'method': 'operation_response',
+        'kind': 'operation_data_kind_wrong',
+        'data': {'value': 'operation_value'}
+      }));
+
+      await expectLater(
+        queue.next.timeout(Duration(milliseconds: 50)),
+        throwsA(isA<TimeoutException>()),
+      );
+    });
   });
 }

--- a/commanddash/test/server/task_assist_test.dart
+++ b/commanddash/test/server/task_assist_test.dart
@@ -1,0 +1,70 @@
+import 'dart:async';
+
+import 'package:commanddash/server/messages.dart';
+import 'package:commanddash/server/operation_message.dart';
+import 'package:commanddash/server/server.dart';
+import 'package:commanddash/server/task_assist.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+import 'package:test/test.dart';
+
+import 'task_assist_test.mocks.dart';
+
+@GenerateMocks([Server])
+void main() {
+  group('TaskAssist', () {
+    late Server server;
+    late TaskAssist taskAssist;
+    late StreamController<IncomingMessage> messageStreamController;
+    setUp(() {
+      server = MockServer();
+      taskAssist = TaskAssist(server, 1);
+      messageStreamController = StreamController.broadcast();
+      when(server.messagesStream)
+          .thenAnswer((_) => messageStreamController.stream);
+    });
+
+    test(
+        'processOperation() closes succesfully when the correct response is receieved',
+        () async {
+      final operationMessage = OperationMessage(kind: 'test', args: {});
+
+      Completer completer = Completer();
+      completer.future.timeout(Duration(milliseconds: 10));
+      // Run the fetch from client
+      taskAssist.processOperation(kind: 'test', args: {}).then((value) {
+        completer.complete(value);
+      });
+      messageStreamController
+          .add(OperationResponseMessage('test', data: {'value': true}));
+
+      await expectLater(
+          await completer.future.timeout(Duration(milliseconds: 10)),
+          {'value': true});
+      verify(server.sendMessage(operationMessage));
+    }, timeout: Timeout(Duration(milliseconds: 100)));
+    test(
+      'processOperation() doesn`t close when an incorrect response is receieved',
+      () async {
+        final operationMessage = OperationMessage(kind: 'test', args: {});
+
+        Completer completer = Completer();
+
+        // Run the fetch from client
+        taskAssist.processOperation(kind: 'test', args: {}).then((value) {
+          // Verify and expect
+          verify(server.sendMessage(operationMessage));
+          expect(value, {'value': true});
+          completer.complete();
+        });
+        messageStreamController
+            .add(OperationResponseMessage('other_test', data: {'value': true}));
+        // Use expectLater with the async matcher completes
+        await expectLater(
+          completer.future.timeout(Duration(milliseconds: 10)),
+          throwsA(isA<TimeoutException>()),
+        );
+      },
+    );
+  }, timeout: Timeout(Duration(milliseconds: 100)));
+}


### PR DESCRIPTION
This PR includes two things:
**1. Independent Operations Support**
These are operations independent of any task. Like asking for client to provide a new access token. Introduced a new API for the same in `TaskAssist`:
```
Future<Map<String, dynamic>> processOperation({
    required String kind,
    required Map<String, dynamic> args,
  })
```
which has only kind and no task ID and behaves almost similar to already existing `processStep`. The client defines and processes these requests globally and not as a part of the task.

**2.  Custom Interceptor for Dio**

This is designed to automatically call the refresh token callback using the newly created independent operation and reattempt the failed API call due to expired token.  Use `getClient` to create a new Dio Client when starting a new task. [demo in TaskHandler]. 

The functionality to create, refresh access token will be on the client side like all other functionalities needed before activating the CLI.