### PR TITLE
improved step outputs and fixed validation

### DIFF
--- a/dash_agent/lib/helpers/agent_validation.dart
+++ b/dash_agent/lib/helpers/agent_validation.dart
@@ -84,8 +84,11 @@ class AgentValidation {
       Map<String, dynamic> step, List<String> registeredVariables) {
     final nonRegisteredPromptIds = _extractNonRegisteredVariablesInStep(
         step['prompt'], registeredVariables);
-    final nonRegisteredOutputIds = _extractNonRegisteredVariablesInStep(
-        step['outputs'], registeredVariables);
+    final stepOutputs = step['outputs'] as List<String>;
+    final nonRegisteredOutputIds = [
+      for (final output in stepOutputs)
+        ..._extractNonRegisteredVariablesInStep(output, registeredVariables)
+    ];
 
     if (nonRegisteredPromptIds.isNotEmpty &&
         nonRegisteredOutputIds.isNotEmpty) {
@@ -102,8 +105,11 @@ class AgentValidation {
       Map<String, dynamic> step, List<String> registeredVariables) {
     final nonRegisteredQueryIds = _extractNonRegisteredVariablesInStep(
         step['query'], registeredVariables);
-    final nonRegisteredOutputIds = _extractNonRegisteredVariablesInStep(
-        step['outputs'], registeredVariables);
+    final stepOutputs = step['outputs'] as List<String>;
+    final nonRegisteredOutputIds = [
+      for (final output in stepOutputs)
+        ..._extractNonRegisteredVariablesInStep(output, registeredVariables)
+    ];
 
     if (nonRegisteredQueryIds.isNotEmpty && nonRegisteredOutputIds.isNotEmpty) {
       return _invalidDashVariableMessage(['query', 'outputs']);
@@ -119,8 +125,11 @@ class AgentValidation {
       Map<String, dynamic> step, List<String> registeredVariables) {
     final nonRegisteredQueryIds = _extractNonRegisteredVariablesInStep(
         step['query'], registeredVariables);
-    final nonRegisteredOutputIds = _extractNonRegisteredVariablesInStep(
-        step['outputs'], registeredVariables);
+    final stepOutputs = step['outputs'] as List<String>;
+    final nonRegisteredOutputIds = [
+      for (final output in stepOutputs)
+        ..._extractNonRegisteredVariablesInStep(output, registeredVariables)
+    ];
 
     if (nonRegisteredQueryIds.isNotEmpty && nonRegisteredOutputIds.isNotEmpty) {
       return _invalidDashVariableMessage(['query', 'outputs']);

--- a/dash_agent/lib/steps/steps.dart
+++ b/dash_agent/lib/steps/steps.dart
@@ -58,7 +58,7 @@ class MatchDocumentStep extends Step {
       'type': 'search_in_sources',
       'query': query,
       'data_sources': [for (final dataSource in dataSources) '$dataSource'],
-      'outputs': '$dashOutputs',
+      'outputs': [for (final dashOutput in dashOutputs) '$dashOutput'],
       'version': version
     };
     return processedJson;
@@ -100,7 +100,7 @@ class WorkspaceQueryStep extends Step {
     final Map<String, dynamic> processedJson = {
       'type': 'search_in_workspace',
       'query': query,
-      'outputs': '$dashOutputs',
+      'outputs': [for (final dashOutput in dashOutputs) '$dashOutput'],
       'version': version
     };
     return processedJson;
@@ -159,7 +159,7 @@ class PromptQueryStep extends Step {
     final Map<String, dynamic> processedJson = {
       'type': 'prompt_query',
       'prompt': prompt,
-      'outputs': '$dashOutputs',
+      'outputs': [for (final dashOutput in dashOutputs) '$dashOutput'],
       'version': version
     };
 
@@ -170,7 +170,8 @@ class PromptQueryStep extends Step {
   String get version => '0.0.1';
 
   @override
-  List<DashOutput> get dashOutputs => [promptOutput, codeOutput].nonNulls.toList();
+  List<DashOutput> get dashOutputs =>
+      [promptOutput, codeOutput].nonNulls.toList();
 }
 
 /// Appends the value to the chat.


### PR DESCRIPTION
@samyakkkk Same here. Improved the dash outputs. Earlier the dash outputs were going in the form of `'[<2442902>]'`. That is a string of list.

 Post this fix dash outputs are stored in the JSON and transmitted ahead as `['<2442902>']`. That is, a list of strings