### PR TITLE
Fail safe error handling

### DIFF
--- a/commanddash/lib/agent/step_model.dart
+++ b/commanddash/lib/agent/step_model.dart
@@ -26,7 +26,6 @@ abstract class Step {
 
   factory Step.fromJson(Map<String, dynamic> json, Map<String, Input> inputs,
       Map<String, Output> outputs, String agentName, String agentVersion) {
-    // TODO: handle parsing error
     switch (json['type']) {
       case 'search_in_workspace':
         return SearchInWorkspaceStep.fromJson(
@@ -79,7 +78,10 @@ abstract class Step {
   Future<Output?> run(
       TaskAssist taskAssist, GenerationRepository generationRepository,
       [DashRepository? dashRepository]) async {
-    await taskAssist.processStep(kind: 'loader_update', args: loader.toJson());
+    await taskAssist.processStep(
+        kind: 'loader_update',
+        args: loader.toJson(),
+        timeoutKind: TimeoutKind.sync);
     return null;
   }
 }

--- a/commanddash/lib/server/task_assist.dart
+++ b/commanddash/lib/server/task_assist.dart
@@ -15,6 +15,9 @@ class TaskAssist {
         .whereType<StepResponseMessage>()
         .where((event) => event.id == _taskId)
         .first;
+    if (dataResponse.data['result'] == 'error') {
+      throw Exception(dataResponse.data['message']);
+    }
     return dataResponse.data;
   }
 

--- a/commanddash/lib/server/task_assist.dart
+++ b/commanddash/lib/server/task_assist.dart
@@ -1,7 +1,31 @@
+import 'dart:async';
+
 import 'package:commanddash/server/messages.dart';
 import 'package:commanddash/server/operation_message.dart';
 import 'package:commanddash/server/server.dart';
 import 'package:rxdart/rxdart.dart';
+
+enum TimeoutKind {
+  /// 6s. Use for almost synchronous tasks like fetching local data.
+  sync,
+
+  /// 60s. Use for finite API call related tasks, like refreshing accessToken.
+  async,
+
+  /// 6 mins. Use for long running tasks like LLM calls (if any at client level).
+  stretched
+}
+
+Duration durationFromTimeoutKind(TimeoutKind kind) {
+  switch (kind) {
+    case TimeoutKind.sync:
+      return Duration(seconds: 6);
+    case TimeoutKind.async:
+      return Duration(seconds: 60);
+    case TimeoutKind.stretched:
+      return Duration(minutes: 6);
+  }
+}
 
 class TaskAssist {
   TaskAssist(this._server, this._taskId);
@@ -41,16 +65,26 @@ class TaskAssist {
   }
 
   /// To perform task independent operationas such as asking client to refresh and provide new access token.
+  ///
+  /// [timeoutKind] should be suitably added depending upon what is expected from the operation
   Future<Map<String, dynamic>> processOperation({
     required String kind,
     required Map<String, dynamic> args,
+    TimeoutKind timeoutKind = TimeoutKind.async,
   }) async {
     _server.sendMessage(OperationMessage(kind: kind, args: args));
 
     final dataResponse = await _server.messagesStream
         .whereType<OperationResponseMessage>()
         .where((event) => event.kind == kind)
-        .first;
+        .first
+        .timeout(durationFromTimeoutKind(timeoutKind), onTimeout: () {
+      throw TimeoutException('Operation timed out fetching $kind');
+    });
+
+    if (dataResponse.data['result'] == 'error') {
+      throw Exception(dataResponse.data['message']);
+    }
     return dataResponse.data;
   }
 }

--- a/commanddash/lib/server/task_handler.dart
+++ b/commanddash/lib/server/task_handler.dart
@@ -16,7 +16,14 @@ class TaskHandler {
       final taskAssist = TaskAssist(_server, message.id);
       switch (message.taskKind) {
         case 'random_task_with_step':
-          randomFunctionWithStep(taskAssist);
+          try {
+            await randomFunctionWithStep(taskAssist);
+          } catch (e, stackTrace) {
+            taskAssist.sendErrorMessage(
+                message: 'Error processing request: ${e.toString()}',
+                data: {},
+                stackTrace: stackTrace);
+          }
           break;
         case 'random_task_with_side_operation':
           try {
@@ -82,7 +89,8 @@ class TaskHandler {
 
 /// Function for Integration Test of the step communication
 Future<void> randomFunctionWithStep(TaskAssist taskAssist) async {
-  final data = await taskAssist.processStep(kind: 'step_data_kind', args: {});
+  final data = await taskAssist.processStep(
+      kind: 'step_data_kind', args: {}, timeoutKind: TimeoutKind.sync);
   if (data['value'] == 'unique_value') {
     taskAssist.sendResultMessage(message: 'TASK_COMPLETED', data: {});
   } else {

--- a/commanddash/lib/server/task_handler.dart
+++ b/commanddash/lib/server/task_handler.dart
@@ -19,18 +19,30 @@ class TaskHandler {
           randomFunctionWithStep(taskAssist);
           break;
         case 'random_task_with_side_operation':
-          randomFunctionWithSideOperation(taskAssist);
+          try {
+            await randomFunctionWithSideOperation(taskAssist);
+          } catch (e, stackTrace) {
+            taskAssist.sendErrorMessage(
+                message: 'Error processing request: ${e.toString()}',
+                data: {},
+                stackTrace: stackTrace);
+          }
+
           break;
         case 'get-agents':
           final client = getClient(
               message.data['auth']['github_access_token'],
-              () async => taskAssist
-                  .processOperation(kind: 'refresh_access_token', args: {}));
+              () async => taskAssist.processOperation(
+                    kind: 'refresh_access_token',
+                    args: {},
+                  ));
           final repo = DashRepository(client);
           try {
             final agents = await repo.getAgents();
             taskAssist.sendResultMessage(
-                message: "Agent get successful", data: {"agents": agents});
+              message: "Agent get successful",
+              data: {"agents": agents},
+            );
           } catch (e, stackTrace) {
             taskAssist.sendErrorMessage(
                 message: "Failed getting agents.",
@@ -41,8 +53,10 @@ class TaskHandler {
         case 'refresh_token_test':
           final client = getClient(
               message.data['auth']['github_access_token'],
-              () async => taskAssist
-                  .processOperation(kind: 'refresh_access_token', args: {}));
+              () async => taskAssist.processOperation(
+                    kind: 'refresh_access_token',
+                    args: {},
+                  ));
           DashRepository(client);
 
           ///Other repositories using the backend client
@@ -81,6 +95,9 @@ Future<void> randomFunctionWithStep(TaskAssist taskAssist) async {
 
 /// Function for Integration Test of the side operation communication
 Future<void> randomFunctionWithSideOperation(TaskAssist taskAssist) async {
-  await taskAssist.processOperation(kind: 'operation_data_kind', args: {});
-  taskAssist.sendResultMessage(message: 'TASK_COMPLETED', data: {});
+  await taskAssist.processOperation(
+      kind: 'operation_data_kind', args: {}, timeoutKind: TimeoutKind.sync);
+  taskAssist.sendLogMessage(message: 'response received', data: {});
+  taskAssist
+      .sendResultMessage(message: 'TASK_COMPLETED', data: {'success': true});
 }

--- a/commanddash/lib/server/task_handler.dart
+++ b/commanddash/lib/server/task_handler.dart
@@ -49,17 +49,16 @@ class TaskHandler {
           ///Pass this to the agent.
           break;
         case 'agent-execute':
-          final handler = AgentHandler.fromJson(message.data);
-          handler.runTask(taskAssist);
+          try {
+            final handler = AgentHandler.fromJson(message.data);
+            await handler.runTask(taskAssist);
+          } catch (e, stackTrace) {
+            taskAssist.sendErrorMessage(
+                message: 'Error processing request: ${e.toString()}',
+                data: {},
+                stackTrace: stackTrace);
+          }
           break;
-        // case 'find_closest_files':
-        //   EmbeddingGenerator().findClosesResults(
-        //     taskAssist,
-        //     message.data['query'],
-        //     message.data['workspacePath'],
-        //     GeminiRepository(message.data['apiKey']),
-        //   );
-        // break;
         default:
           taskAssist.sendErrorMessage(message: 'INVALID_TASK_KIND', data: {});
       }

--- a/commanddash/lib/server/task_handler.dart
+++ b/commanddash/lib/server/task_handler.dart
@@ -15,6 +15,8 @@ class TaskHandler {
         .listen((TaskStartMessage message) async {
       final taskAssist = TaskAssist(_server, message.id);
       switch (message.taskKind) {
+        case 'random_task_global_error':
+          throw Exception('Some unhandled exception not tracked to a task.');
         case 'random_task_with_step':
           try {
             await randomFunctionWithStep(taskAssist);

--- a/commanddash/lib/steps/append_to_chat/append_to_chat_step.dart
+++ b/commanddash/lib/steps/append_to_chat/append_to_chat_step.dart
@@ -30,8 +30,10 @@ class AppendToChatStep extends Step {
       TaskAssist taskAssist, GenerationRepository generationRepository,
       [DashRepository? dashRepository]) async {
     await super.run(taskAssist, generationRepository);
-    final response = await taskAssist
-        .processStep(kind: 'append_to_chat', args: {'message': message});
+    final response = await taskAssist.processStep(
+        kind: 'append_to_chat',
+        args: {'message': message},
+        timeoutKind: TimeoutKind.sync);
     if (response['error'] != null) {
       throw Exception(response['error']['message']);
     }

--- a/commanddash/lib/steps/find_closest_files/search_in_workspace_step.dart
+++ b/commanddash/lib/steps/find_closest_files/search_in_workspace_step.dart
@@ -1,5 +1,3 @@
-import 'package:commanddash/agent/agent_exceptions.dart';
-import 'package:commanddash/agent/input_model.dart';
 import 'package:commanddash/agent/loader_model.dart';
 import 'package:commanddash/agent/output_model.dart';
 import 'package:commanddash/agent/step_model.dart';
@@ -44,7 +42,8 @@ class SearchInWorkspaceStep extends Step {
       [DashRepository? dashRepository]) async {
     await super.run(taskAssist, generationRepository);
     final dartFiles = EmbeddingGenerator.getDartFiles(workspacePath);
-    final codeCacheHash = await taskAssist.processStep(kind: 'cache', args: {});
+    final codeCacheHash = await taskAssist.processStep(
+        kind: 'cache', args: {}, timeoutKind: TimeoutKind.sync);
     final filesToUpdate =
         EmbeddingGenerator.getFilesToUpdate(dartFiles, codeCacheHash);
     final embeddedFiles = await EmbeddingGenerator.updateEmbeddings(

--- a/commanddash/lib/steps/replace_in_file/replace_in_file_step.dart
+++ b/commanddash/lib/steps/replace_in_file/replace_in_file_step.dart
@@ -34,10 +34,12 @@ class ReplaceInFileStep extends Step {
       TaskAssist taskAssist, GenerationRepository generationRepository,
       [DashRepository? dashRepository]) async {
     await super.run(taskAssist, generationRepository);
-    final response =
-        await taskAssist.processStep(kind: 'replace_in_file', args: {
-      'file': file.getReplaceFileJson(newContent),
-    });
+    final response = await taskAssist.processStep(
+        kind: 'replace_in_file',
+        args: {
+          'file': file.getReplaceFileJson(newContent),
+        },
+        timeoutKind: TimeoutKind.stretched);
     final userChoice = response['value'] as bool;
     if (userChoice == false && continueIfDeclined == false) {
       return ContinueToNextStepOutput(false);

--- a/commanddash/test/steps/append_to_chat/append_to_chat_test.dart
+++ b/commanddash/test/steps/append_to_chat/append_to_chat_test.dart
@@ -34,7 +34,9 @@ void main() {
 
     test('run throws an exception if the response contains an error', () async {
       when(taskAssist.processStep(
-              kind: 'append_to_chat', args: {'message': 'message'}))
+              kind: 'append_to_chat',
+              args: {'message': 'message'},
+              timeoutKind: TimeoutKind.sync))
           .thenAnswer((_) async => {
                 'error': {'message': 'error message'}
               });
@@ -47,8 +49,10 @@ void main() {
     test('run returns null if the response does not contain an error',
         () async {
       when(taskAssist.processStep(
-          kind: 'append_to_chat',
-          args: {'message': 'message'})).thenAnswer((_) async => {});
+              kind: 'append_to_chat',
+              args: {'message': 'message'},
+              timeoutKind: TimeoutKind.sync))
+          .thenAnswer((_) async => {});
 
       expect(await step.run(taskAssist, generationRepository), isNull);
     });


### PR DESCRIPTION
Two possible failure places are:

### CLI throws exception during processing

- Added try/catch over each task execution that sends a error message to IDE.
- Errors that couldn't be linked to a task, say failure while parsing `IncomingMessage` are reported back as global errors to the IDE.

### IDE fails to return required data.
- If IDE doesn't have handler for any of the fetch requests, it will send back an error response. CLI will then handle the case or throw an error.
- Introduced TimeoutKind, that limits the time it should take for IDE to process fetch requests. It has 3 options, 6s, 60s, 6 mins.

The counterpart IDE PR will be linked in comments.
