### PR TITLE
workspace path shouldn't be part of agent json

### DIFF
--- a/commanddash/lib/server/messages.dart
+++ b/commanddash/lib/server/messages.dart
@@ -33,36 +33,6 @@ class IncomingMessage extends Equatable {
   List<Object?> get props => [id];
 }
 
-class GenerationTask extends TaskStartMessage {
-  final String apiKey;
-
-  GenerationTask(int id,
-      {required String taskKind,
-      required Map<String, dynamic> data,
-      required this.apiKey})
-      : super(id, taskKind: taskKind, data: data);
-}
-
-class ClosestFileTask extends GenerationTask {
-  final String query;
-  final String workspacePath;
-
-  ClosestFileTask(
-      {required int id,
-      required this.query,
-      required this.workspacePath,
-      required Map<String, dynamic> data})
-      : super(id, taskKind: 'find-closest-files', data: data, apiKey: '');
-
-  factory ClosestFileTask.fromJson(int id, Map<String, dynamic> json) {
-    return ClosestFileTask(
-        id: id,
-        query: json['query'],
-        workspacePath: json['workspacePath'],
-        data: json['data']);
-  }
-}
-
 class TaskStartMessage extends IncomingMessage {
   final String taskKind; // agent-execute
   final Map<String, dynamic> data;

--- a/commanddash/test/steps/find_closest_file_test.dart
+++ b/commanddash/test/steps/find_closest_file_test.dart
@@ -13,6 +13,7 @@ void main() {
   late TaskHandler handler;
   late StreamController<IncomingMessage> messageStreamController;
   late TestOutWrapper outwrapper;
+
   setUp(() async {
     await EnvReader.load();
     server = Server();
@@ -22,7 +23,8 @@ void main() {
     server.stdout = outwrapper;
     handler = TaskHandler(server);
   });
-  test('Process a search_in_workspace request', () async {
+
+  test('Processing search_in_workspace executes successfully', () async {
     handler.initProcessing();
 
     messageStreamController.add(IncomingMessage.fromJson({
@@ -49,8 +51,6 @@ void main() {
             "type": "search_in_workspace",
             "query": "<422243666>",
             "workspace_object_type": "all",
-            "workspacePath":
-                "/Users/keval/Desktop/dev/welltested/projects/dart_files",
             "outputs": ["436621806"]
           }
         ]
@@ -66,19 +66,152 @@ void main() {
     messageStreamController
         .add(StepResponseMessage(1, 'loader_update', data: {}));
     result = await queue.next;
+    expect(result, isA<StepMessage>());
+    expect(result.id, 1);
+    expect((result as StepMessage).kind, 'workspace_details');
+    expect(result.args, {});
+    messageStreamController.add(StepResponseMessage(1, 'workspace_details',
+        data: {'path': EnvReader.get('OPEN_WORKSPACE_PATH')}));
 
+    result = await queue.next;
     expect(result, isA<StepMessage>());
     expect(result.id, 1);
     expect((result as StepMessage).kind, 'cache');
     expect(result.args, {});
 
     messageStreamController
-        .add(StepResponseMessage(1, 'cache_response', data: {'value': '{}'}));
+        .add(StepResponseMessage(1, 'cache', data: {'value': '{}'}));
 
     result = await queue.next;
     expect(result, isA<ResultMessage>());
     expect(result.id, 1);
     expect((result as ResultMessage).message, 'TASK_COMPLETE');
-    expect((result as ResultMessage).message, isNotEmpty);
+    expect((result).message, isNotEmpty);
+  });
+
+  test(
+      'Processing search_in_workspace gives no workspace found error if workspace path is provided null from client',
+      () async {
+    handler.initProcessing();
+
+    messageStreamController.add(IncomingMessage.fromJson({
+      "method": "agent-execute",
+      "id": 1,
+      "params": {
+        "authdetails": {
+          "type": "gemini",
+          "key": EnvReader.get('GEMINI_KEY'),
+          "githubToken": ""
+        },
+        "registered_inputs": [
+          {
+            "id": "736841542",
+            "type": "string_input",
+            "value": "Where is the themeing of the app?"
+          }
+        ],
+        "registered_outputs": [
+          {"id": "436621806", "type": "default_output"}
+        ],
+        "steps": [
+          {
+            "type": "search_in_workspace",
+            "query": "<422243666>",
+            "workspace_object_type": "all",
+            "outputs": ["436621806"]
+          }
+        ]
+      }
+    }));
+
+    final queue = StreamQueue<OutgoingMessage>(outwrapper.outputStream.stream);
+    var result = await queue.next;
+    expect(result.id, 1);
+    expect((result as StepMessage).kind, 'loader_update');
+    expect(result.args['kind'], 'message');
+    expect(result.args['message'], 'Finding relevant files');
+    messageStreamController
+        .add(StepResponseMessage(1, 'loader_update', data: {}));
+    result = await queue.next;
+    expect(result, isA<StepMessage>());
+    expect(result.id, 1);
+    expect((result as StepMessage).kind, 'workspace_details');
+    expect(result.args, {});
+    messageStreamController
+        .add(StepResponseMessage(1, 'workspace_details', data: {'path': null}));
+
+    result = await queue.next;
+    expect(result, isA<ErrorMessage>());
+    expect(result.id, 1);
+    expect((result as ErrorMessage).message, 'No open workspace found');
+    expect(result.data, {'stack_trace': null});
+
+    try {
+      result = await queue.next.timeout(Duration(seconds: 1));
+      throw Exception('More events found when the stream was supposed to end');
+    } catch (_) {}
+  });
+
+  test(
+      'Processing search_in_workspace gives no workspace found error if workspace path is provided empty from client',
+      () async {
+    handler.initProcessing();
+
+    messageStreamController.add(IncomingMessage.fromJson({
+      "method": "agent-execute",
+      "id": 1,
+      "params": {
+        "authdetails": {
+          "type": "gemini",
+          "key": EnvReader.get('GEMINI_KEY'),
+          "githubToken": ""
+        },
+        "registered_inputs": [
+          {
+            "id": "736841542",
+            "type": "string_input",
+            "value": "Where is the themeing of the app?"
+          }
+        ],
+        "registered_outputs": [
+          {"id": "436621806", "type": "default_output"}
+        ],
+        "steps": [
+          {
+            "type": "search_in_workspace",
+            "query": "<422243666>",
+            "workspace_object_type": "all",
+            "outputs": ["436621806"]
+          }
+        ]
+      }
+    }));
+
+    final queue = StreamQueue<OutgoingMessage>(outwrapper.outputStream.stream);
+    var result = await queue.next;
+    expect(result.id, 1);
+    expect((result as StepMessage).kind, 'loader_update');
+    expect(result.args['kind'], 'message');
+    expect(result.args['message'], 'Finding relevant files');
+    messageStreamController
+        .add(StepResponseMessage(1, 'loader_update', data: {}));
+    result = await queue.next;
+    expect(result, isA<StepMessage>());
+    expect(result.id, 1);
+    expect((result as StepMessage).kind, 'workspace_details');
+    expect(result.args, {});
+    messageStreamController
+        .add(StepResponseMessage(1, 'workspace_details', data: {'path': ''}));
+
+    result = await queue.next;
+    expect(result, isA<ErrorMessage>());
+    expect(result.id, 1);
+    expect((result as ErrorMessage).message, 'No open workspace found');
+    expect(result.data, {'stack_trace': null});
+
+    try {
+      result = await queue.next.timeout(Duration(seconds: 1));
+      throw Exception('More events found when the stream was supposed to end');
+    } catch (_) {}
   });
 }

--- a/commanddash/test/steps/workspace_query_test.dart
+++ b/commanddash/test/steps/workspace_query_test.dart
@@ -51,13 +51,11 @@ void main() {
             "type": "search_in_workspace",
             "query": "<422243666>",
             "workspace_object_type": "all",
-            "workspacePath":
-                "/Users/keval/Desktop/dev/welltested/projects/dart_files",
             "outputs": ["436621806"]
           },
           {
             "type": "prompt_query",
-            "query":
+            "prompt":
                 "Here are the related references from user's project:\n <436621806>. Answer the user's query. Query: <736841542>",
             "post_process": {"type": "raw"},
             "outputs": ["90611917"]
@@ -80,6 +78,14 @@ void main() {
     expect(result.args['message'], 'Finding relevant files');
     messageStreamController
         .add(StepResponseMessage(1, 'loader_update', data: {}));
+
+    result = await queue.next;
+    expect(result, isA<StepMessage>());
+    expect(result.id, 1);
+    expect((result as StepMessage).kind, 'workspace_details');
+    expect(result.args, {});
+    messageStreamController.add(StepResponseMessage(1, 'workspace_details',
+        data: {'path': EnvReader.get('OPEN_WORKSPACE_PATH')}));
     result = await queue.next;
 
     expect(result, isA<StepMessage>());
@@ -88,7 +94,7 @@ void main() {
     expect(result.args, {});
 
     messageStreamController
-        .add(StepResponseMessage(1, 'cache_response', data: {'value': '{}'}));
+        .add(StepResponseMessage(1, 'cache', data: {'value': '{}'}));
 
     result = await queue.next;
     expect(result, isA<StepMessage>());


### PR DESCRIPTION
Anything specific to workspace shouldn't be a part of agent JSON. 

Either make it a global agent param like `authDetails` or fetch it during runtime. making values specific part of steps, the IDE will not have the ability to provide. 