### PR TITLE
(fix): workspace matching algorithm fix

### DIFF
--- a/commanddash/lib/agent/output_model.dart
+++ b/commanddash/lib/agent/output_model.dart
@@ -49,7 +49,7 @@ class MultiCodeOutput extends Output {
       return code;
     } else {
       for (WorkspaceFile file in value!) {
-        if (code.length > 12000) {
+        if (code.length > 18000) {
           break; //maximum char limit ?? TODO: Replace this later with a holistic counting mechanism
         }
         code += 'File: ${file.path}\n';

--- a/commanddash/lib/server/server.dart
+++ b/commanddash/lib/server/server.dart
@@ -50,3 +50,11 @@ class StdOutWrapper implements OutWrapper {
 abstract class OutWrapper {
   void writeOutgoingMessage(OutgoingMessage message);
 }
+
+/// Use this method to print logs on the IDE when debugging
+///
+/// The benefit is that it does not require [TaskAssist]. Do not ship with [sendDebugMessage] active in code.
+sendDebugMessage(Map<String, dynamic> data) {
+  print(jsonEncode(
+      {'id': 'independent', 'method': 'debug_message', 'params': data}));
+}

--- a/commanddash/lib/steps/find_closest_files/embedding_generator.dart
+++ b/commanddash/lib/steps/find_closest_files/embedding_generator.dart
@@ -69,8 +69,8 @@ class EmbeddingGenerator {
           calculateCosineSimilarity(queryEmbeddings, a.embedding!);
       final distanceB =
           calculateCosineSimilarity(queryEmbeddings, b.embedding!);
-      return distanceA.compareTo(distanceB);
+      return distanceB.compareTo(distanceA);
     }));
-    return files;
+    return files.sublist(0, 3);
   }
 }

--- a/commanddash/test/token_count_calculator.dart
+++ b/commanddash/test/token_count_calculator.dart
@@ -1,0 +1,18 @@
+import 'package:google_generative_ai/google_generative_ai.dart';
+import 'package:test/test.dart';
+
+import 'test_utils.dart';
+
+/// Helper test to fetch token counts of texts.
+void main() {
+  test('token count', () async {
+    await EnvReader.load();
+    final model = GenerativeModel(
+        model: 'gemini-pro', apiKey: EnvReader.get('GEMINI_KEY') ?? '');
+    final value = await model.countTokens([Content.text(text)]);
+    print(value.totalTokens);
+    print(text.length);
+  });
+}
+
+const text = 'mock_text';


### PR DESCRIPTION
The files were being sorted in the opposite direction leading to the least relevant files being attached instead. 

This is fixed, along with which a hard limit for 18000 char (roughly 6000 tokens) for `MultiCodeOutput` is set.