### PR TITLE
Fix breaking conextual code for non dart files

### DIFF
--- a/commanddash/lib/steps/prompt_query/prompt_query_step.dart
+++ b/commanddash/lib/steps/prompt_query/prompt_query_step.dart
@@ -118,10 +118,12 @@ class PromptQueryStep extends Step {
                 timeoutKind: TimeoutKind.stretched,
               );
               final context = data['context'];
-              final listOfContext = List<Map<String, dynamic>>.from(context);
-              for (final nestedCode in listOfContext) {
-                final filePath = nestedCode['filePath'];
-                appendNestedCodeCount(filePath);
+              if (context != null) {
+                final listOfContext = List<Map<String, dynamic>>.from(context);
+                for (final nestedCode in listOfContext) {
+                  final filePath = nestedCode['filePath'];
+                  appendNestedCodeCount(filePath);
+                }
               }
             }
             break;


### PR DESCRIPTION
When non dart files were attached, context received as null from client which broke the logic.