### PR TITLE
Include all language files in workspace query

### DIFF
--- a/commanddash/lib/steps/find_closest_files/search_in_workspace_step.dart
+++ b/commanddash/lib/steps/find_closest_files/search_in_workspace_step.dart
@@ -49,7 +49,7 @@ class SearchInWorkspaceStep extends Step {
       taskAssist.sendErrorMessage(message: "No open workspace found", data: {});
       throw Exception("No open workspace found");
     }
-    final dartFiles = EmbeddingGenerator.getDartFiles(workspacePath);
+    final dartFiles = EmbeddingGenerator.getProjectFiles(workspacePath);
     final codeCacheHash = jsonDecode((await taskAssist.processStep(
         kind: 'cache', args: {}, timeoutKind: TimeoutKind.sync))['value']);
     final filesToUpdate =


### PR DESCRIPTION
All language files should be allowed in the workspace query to provide better context and allow functionality of the extension for other languages than Dart too.

The PR also handles to not include files which may not be required by using the .gitIgnore file in any project.
Any file in .gitignore is considered as not an important context for the model request.